### PR TITLE
JDBC access to arrow data

### DIFF
--- a/java/.gitignore
+++ b/java/.gitignore
@@ -3,6 +3,7 @@
 .classpath
 .checkstyle
 .settings/
+.factorypath
 .idea/
 TAGS
 *.log

--- a/java/adapter/jdbc/pom.xml
+++ b/java/adapter/jdbc/pom.xml
@@ -84,18 +84,4 @@
         </dependency>
 
     </dependencies>
-
-    <build>	
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <user.timezone>UTC</user.timezone>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/ArrowVectorIterator.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/ArrowVectorIterator.java
@@ -18,164 +18,27 @@
 package org.apache.arrow.adapter.jdbc;
 
 import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.Iterator;
 
-import org.apache.arrow.adapter.jdbc.consumer.CompositeJdbcConsumer;
-import org.apache.arrow.adapter.jdbc.consumer.JdbcConsumer;
-import org.apache.arrow.util.Preconditions;
+import org.apache.arrow.sql.ArrowResultSet;
 import org.apache.arrow.vector.VectorSchemaRoot;
-import org.apache.arrow.vector.types.pojo.Schema;
-import org.apache.arrow.vector.util.ValueVectorUtility;
 
 /**
- * VectorSchemaRoot iterator for partially converting JDBC data.
+ * VectorSchemaRoot iterator over JDBC data.
  */
-public class ArrowVectorIterator implements Iterator<VectorSchemaRoot>, AutoCloseable {
-
-  private final ResultSet resultSet;
-  private final JdbcToArrowConfig config;
-
-  private final Schema schema;
-  private final ResultSetMetaData rsmd;
-
-  private final JdbcConsumer[] consumers;
-  final CompositeJdbcConsumer compositeConsumer;
-
-  private VectorSchemaRoot nextBatch;
-
-  private final int targetBatchSize;
-
-  /**
-   * Construct an instance.
-   */
-  private ArrowVectorIterator(ResultSet resultSet, JdbcToArrowConfig config) throws SQLException {
-    this.resultSet = resultSet;
-    this.config = config;
-    this.schema = JdbcToArrowUtils.jdbcToArrowSchema(resultSet.getMetaData(), config);
-    this.targetBatchSize = config.getTargetBatchSize();
-
-    rsmd = resultSet.getMetaData();
-    consumers = new JdbcConsumer[rsmd.getColumnCount()];
-    this.compositeConsumer = new CompositeJdbcConsumer(consumers);
-  }
-
-  private void initialize() throws SQLException {
-    // create consumers
-    for (int i = 1; i <= consumers.length; i++) {
-      consumers[i - 1] = JdbcToArrowUtils.getConsumer(resultSet, i, resultSet.getMetaData().getColumnType(i),
-          null, config);
-    }
-
-    load(createVectorSchemaRoot());
-  }
+public interface ArrowVectorIterator extends Iterator<VectorSchemaRoot>, AutoCloseable {
+  @Override
+  void close();
 
   /**
    * Create a ArrowVectorIterator to partially convert data.
    */
-  public static ArrowVectorIterator create(
-      ResultSet resultSet,
-      JdbcToArrowConfig config)
+  static ArrowVectorIterator create(ResultSet resultSet, JdbcToArrowConfig config)
       throws SQLException {
-
-    ArrowVectorIterator iterator = new ArrowVectorIterator(resultSet, config);
-    try {
-      iterator.initialize();
-      return iterator;
-    } catch (Exception e) {
-      iterator.close();
-      throw new RuntimeException("Error occurred while creating iterator.", e);
+    if (resultSet.isWrapperFor(ArrowResultSet.class)) {
+      return DirectArrowVectorIterator.create(resultSet, config);
     }
-  }
-
-  private void consumeData(VectorSchemaRoot root) {
-    // consume data
-    try {
-      int readRowCount = 0;
-      if (targetBatchSize == JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE) {
-        while (resultSet.next()) {
-          ValueVectorUtility.ensureCapacity(root, readRowCount + 1);
-          compositeConsumer.consume(resultSet);
-          readRowCount++;
-        }
-      } else {
-        while (readRowCount < targetBatchSize && resultSet.next()) {
-          compositeConsumer.consume(resultSet);
-          readRowCount++;
-        }
-      }
-
-
-      root.setRowCount(readRowCount);
-    } catch (Exception e) {
-      compositeConsumer.close();
-      throw new RuntimeException("Error occurred while consuming data.", e);
-    }
-  }
-
-  private VectorSchemaRoot createVectorSchemaRoot() {
-    VectorSchemaRoot root = null;
-    try {
-      root = VectorSchemaRoot.create(schema, config.getAllocator());
-      if (config.getTargetBatchSize() != JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE) {
-        ValueVectorUtility.preAllocate(root, config.getTargetBatchSize());
-      }
-    } catch (Exception e) {
-      if (root != null) {
-        root.close();
-      }
-      throw new RuntimeException("Error occurred while creating schema root.", e);
-    }
-    return root;
-  }
-
-  // Loads the next schema root or null if no more rows are available.
-  private void load(VectorSchemaRoot root) throws SQLException {
-
-    for (int i = 1; i <= consumers.length; i++) {
-      consumers[i - 1].resetValueVector(root.getVector(rsmd.getColumnName(i)));
-    }
-
-    consumeData(root);
-
-    if (root.getRowCount() == 0) {
-      root.close();
-      nextBatch = null;
-    } else {
-      nextBatch = root;
-    }
-  }
-
-  @Override
-  public boolean hasNext() {
-    return nextBatch != null;
-  }
-
-  /**
-   * Gets the next vector. The user is responsible for freeing its resources.
-   */
-  @Override
-  public VectorSchemaRoot next() {
-    Preconditions.checkArgument(hasNext());
-    VectorSchemaRoot returned = nextBatch;
-    try {
-      load(createVectorSchemaRoot());
-    } catch (Exception e) {
-      close();
-      throw new RuntimeException("Error occurred while getting next schema root.", e);
-    }
-    return returned;
-  }
-
-  /**
-   * Clean up resources.
-   */
-  @Override
-  public void close() {
-    if (nextBatch != null) {
-      nextBatch.close();
-    }
-    compositeConsumer.close();
+    return IndirectArrowVectorIterator.create(resultSet, config);
   }
 }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/DirectArrowVectorIterator.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/DirectArrowVectorIterator.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.adapter.jdbc;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.apache.arrow.sql.ArrowResultSet;
+import org.apache.arrow.util.Preconditions;
+import org.apache.arrow.vector.VectorSchemaRoot;
+
+/**
+ * VectorSchemaRoot iterator directly getting data from {@code ArrowResultSet}.
+ */
+class DirectArrowVectorIterator implements ArrowVectorIterator {
+
+  private final ArrowResultSet resultSet;
+
+  private VectorSchemaRoot nextBatch;
+
+  /**
+   * Construct an instance.
+   */
+  private DirectArrowVectorIterator(ArrowResultSet resultSet) throws SQLException {
+    this.resultSet = resultSet;
+  }
+
+  private void load() throws SQLException {
+    nextBatch = resultSet.next() ? resultSet.getRoot() : null;
+  }
+
+  /**
+   * Create a ArrowVectorIterator to partially convert data.
+   */
+  static DirectArrowVectorIterator create(
+      ResultSet resultSet,
+      JdbcToArrowConfig config)
+      throws SQLException {
+    Preconditions.checkArgument(resultSet.isWrapperFor(ArrowResultSet.class));
+
+    DirectArrowVectorIterator iterator = new DirectArrowVectorIterator(resultSet.unwrap(ArrowResultSet.class));
+    try {
+      iterator.load();
+      return iterator;
+    } catch (SQLException e) {
+      try {
+        iterator.close();
+      } catch (Exception closeException) {
+        e.addSuppressed(closeException);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public boolean hasNext() {
+    return nextBatch != null;
+  }
+
+  /**
+   * Gets the next vector. The user is responsible for freeing its resources.
+   */
+  @Override
+  public VectorSchemaRoot next() {
+    Preconditions.checkArgument(hasNext());
+    VectorSchemaRoot returned = nextBatch;
+    try {
+      load();
+    } catch (SQLException e) {
+      close();
+      throw new RuntimeException("Error occurred while getting next schema root.", e);
+    }
+    return returned;
+  }
+
+  /**
+   * Clean up resources.
+   */
+  @Override
+  public void close() {
+  }
+}

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/IndirectArrowVectorIterator.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/IndirectArrowVectorIterator.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.adapter.jdbc;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+
+import org.apache.arrow.adapter.jdbc.consumer.CompositeJdbcConsumer;
+import org.apache.arrow.adapter.jdbc.consumer.JdbcConsumer;
+import org.apache.arrow.util.Preconditions;
+import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.arrow.vector.util.ValueVectorUtility;
+
+/**
+ * VectorSchemaRoot iterator for partially converting JDBC data.
+ */
+class IndirectArrowVectorIterator implements ArrowVectorIterator {
+
+  private final ResultSet resultSet;
+  private final JdbcToArrowConfig config;
+
+  private final Schema schema;
+  private final ResultSetMetaData rsmd;
+
+  private final JdbcConsumer<?>[] consumers;
+  final CompositeJdbcConsumer compositeConsumer;
+
+  private VectorSchemaRoot nextBatch;
+
+  private final int targetBatchSize;
+
+  /**
+   * Construct an instance.
+   */
+  private IndirectArrowVectorIterator(ResultSet resultSet, JdbcToArrowConfig config) throws SQLException {
+    this.resultSet = resultSet;
+    this.config = config;
+    this.schema = JdbcToArrowUtils.jdbcToArrowSchema(resultSet.getMetaData(), config);
+    this.targetBatchSize = config.getTargetBatchSize();
+
+    rsmd = resultSet.getMetaData();
+    consumers = new JdbcConsumer[rsmd.getColumnCount()];
+    this.compositeConsumer = new CompositeJdbcConsumer(consumers);
+  }
+
+  private void initialize() throws SQLException {
+    // create consumers
+    for (int i = 1; i <= consumers.length; i++) {
+      consumers[i - 1] = JdbcToArrowUtils.getConsumer(resultSet, i, resultSet.getMetaData().getColumnType(i),
+          null, config);
+    }
+
+    load(createVectorSchemaRoot());
+  }
+
+  /**
+   * Create a ArrowVectorIterator to partially convert data.
+   */
+  static IndirectArrowVectorIterator create(
+      ResultSet resultSet,
+      JdbcToArrowConfig config)
+      throws SQLException {
+
+    IndirectArrowVectorIterator iterator = new IndirectArrowVectorIterator(resultSet, config);
+    try {
+      iterator.initialize();
+      return iterator;
+    } catch (Exception e) {
+      iterator.close();
+      throw new RuntimeException("Error occurred while creating iterator.", e);
+    }
+  }
+
+  private void consumeData(VectorSchemaRoot root) {
+    // consume data
+    try {
+      int readRowCount = 0;
+      if (targetBatchSize == JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE) {
+        while (resultSet.next()) {
+          ValueVectorUtility.ensureCapacity(root, readRowCount + 1);
+          compositeConsumer.consume(resultSet);
+          readRowCount++;
+        }
+      } else {
+        while (readRowCount < targetBatchSize && resultSet.next()) {
+          compositeConsumer.consume(resultSet);
+          readRowCount++;
+        }
+      }
+
+
+      root.setRowCount(readRowCount);
+    } catch (Exception e) {
+      compositeConsumer.close();
+      throw new RuntimeException("Error occurred while consuming data.", e);
+    }
+  }
+
+  private VectorSchemaRoot createVectorSchemaRoot() {
+    VectorSchemaRoot root = null;
+    try {
+      root = VectorSchemaRoot.create(schema, config.getAllocator());
+      if (config.getTargetBatchSize() != JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE) {
+        ValueVectorUtility.preAllocate(root, config.getTargetBatchSize());
+      }
+    } catch (Exception e) {
+      if (root != null) {
+        root.close();
+      }
+      throw new RuntimeException("Error occurred while creating schema root.", e);
+    }
+    return root;
+  }
+
+  // Loads the next schema root or null if no more rows are available.
+  private void load(VectorSchemaRoot root) throws SQLException {
+
+    for (int i = 1; i <= consumers.length; i++) {
+      resetValueVector(i, root.getVector(rsmd.getColumnName(i)));
+    }
+
+    consumeData(root);
+
+    if (root.getRowCount() == 0) {
+      root.close();
+      nextBatch = null;
+    } else {
+      nextBatch = root;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private <V extends ValueVector> void resetValueVector(int i, V vector) {
+    ((JdbcConsumer<V>) consumers[i - 1]).resetValueVector(vector);
+  }
+
+  @Override
+  public boolean hasNext() {
+    return nextBatch != null;
+  }
+
+  /**
+   * Gets the next vector. The user is responsible for freeing its resources.
+   */
+  @Override
+  public VectorSchemaRoot next() {
+    Preconditions.checkArgument(hasNext());
+    VectorSchemaRoot returned = nextBatch;
+    try {
+      load(createVectorSchemaRoot());
+    } catch (Exception e) {
+      close();
+      throw new RuntimeException("Error occurred while getting next schema root.", e);
+    }
+    return returned;
+  }
+
+  /**
+   * Clean up resources.
+   */
+  @Override
+  public void close() {
+    if (nextBatch != null) {
+      nextBatch.close();
+    }
+    compositeConsumer.close();
+  }
+}

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfig.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfig.java
@@ -71,7 +71,7 @@ public final class JdbcToArrowConfig {
   /**
    * Constructs a new configuration from the provided allocator and calendar.  The <code>allocator</code>
    * is used when constructing the Arrow vectors from the ResultSet, and the calendar is used to define
-   * Arrow Timestamp fields, and to read time-based fields from the JDBC <code>ResultSet</code>. 
+   * Arrow Timestamp fields, and to read time-based fields from the JDBC <code>ResultSet</code>.
    *
    * @param allocator       The memory allocator to construct the Arrow vectors with.
    * @param calendar        The calendar to use when constructing Timestamp fields and reading time-based results.
@@ -89,7 +89,7 @@ public final class JdbcToArrowConfig {
   /**
    * Constructs a new configuration from the provided allocator and calendar.  The <code>allocator</code>
    * is used when constructing the Arrow vectors from the ResultSet, and the calendar is used to define
-   * Arrow Timestamp fields, and to read time-based fields from the JDBC <code>ResultSet</code>. 
+   * Arrow Timestamp fields, and to read time-based fields from the JDBC <code>ResultSet</code>.
    *
    * @param allocator       The memory allocator to construct the Arrow vectors with.
    * @param calendar        The calendar to use when constructing Timestamp fields and reading time-based results.

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/ArrayConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/ArrayConsumer.java
@@ -35,7 +35,7 @@ public abstract class ArrayConsumer extends BaseConsumer<ListVector> {
    * Creates a consumer for {@link ListVector}.
    */
   public static ArrayConsumer createConsumer(
-          ListVector vector, JdbcConsumer delegate, int index, boolean nullable) {
+          ListVector vector, JdbcConsumer<ListVector> delegate, int index, boolean nullable) {
     if (nullable) {
       return new ArrayConsumer.NullableArrayConsumer(vector, delegate, index);
     } else {
@@ -43,7 +43,7 @@ public abstract class ArrayConsumer extends BaseConsumer<ListVector> {
     }
   }
 
-  protected final JdbcConsumer delegate;
+  protected final JdbcConsumer<ListVector> delegate;
 
   private final ValueVector innerVector;
 
@@ -52,7 +52,7 @@ public abstract class ArrayConsumer extends BaseConsumer<ListVector> {
   /**
    * Instantiate a ArrayConsumer.
    */
-  public ArrayConsumer(ListVector vector, JdbcConsumer delegate, int index) {
+  public ArrayConsumer(ListVector vector, JdbcConsumer<ListVector> delegate, int index) {
     super(vector, index);
     this.delegate = delegate;
     this.innerVector = vector.getDataVector();
@@ -78,7 +78,7 @@ public abstract class ArrayConsumer extends BaseConsumer<ListVector> {
     /**
      * Instantiate a nullable array consumer.
      */
-    public NullableArrayConsumer(ListVector vector, JdbcConsumer delegate, int index) {
+    public NullableArrayConsumer(ListVector vector, JdbcConsumer<ListVector> delegate, int index) {
       super(vector, delegate, index);
     }
 

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTest.java
@@ -132,6 +132,7 @@ public class JdbcToArrowTest extends AbstractJdbcToArrowTest {
   /**
    * Test Method to test JdbcToArrow Functionality for various H2 DB based datatypes with only one test data file.
    */
+  @Override
   @Test
   public void testJdbcToArrowValues() throws SQLException, IOException {
     testDataSets(JdbcToArrow.sqlToArrow(conn, table.getQuery(), new RootAllocator(Integer.MAX_VALUE),
@@ -166,6 +167,7 @@ public class JdbcToArrowTest extends AbstractJdbcToArrowTest {
    *
    * @param root VectorSchemaRoot for test
    */
+  @Override
   public void testDataSets(VectorSchemaRoot root) {
     JdbcToArrowTestHelper.assertFieldMetadataIsEmpty(root);
 

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowVectorIteratorTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowVectorIteratorTest.java
@@ -17,7 +17,14 @@
 
 package org.apache.arrow.adapter.jdbc.h2;
 
-import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.*;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.getBinaryValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.getBooleanValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.getCharArray;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.getDecimalValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.getDoubleValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.getFloatValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.getIntValues;
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper.getLongValues;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/java/adapter/orc/pom.xml
+++ b/java/adapter/orc/pom.xml
@@ -103,16 +103,5 @@
                 </includes>
             </resource>
         </resources>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <user.timezone>UTC</user.timezone>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
-        </plugins>
     </build>
 </project>

--- a/java/performance/src/test/java/org/apache/arrow/adapter/jdbc/JdbcAdapterBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/adapter/jdbc/JdbcAdapterBenchmarks.java
@@ -248,7 +248,7 @@ public class JdbcAdapterBenchmarks {
 
     private JdbcToArrowConfig config;
 
-    private ArrowVectorIterator iter;
+    private IndirectArrowVectorIterator iter;
 
     private VectorSchemaRoot root;
 
@@ -281,7 +281,7 @@ public class JdbcAdapterBenchmarks {
       statement = conn.createStatement();
       resultSet = statement.executeQuery(QUERY);
 
-      iter = JdbcToArrow.sqlToArrowVectorIterator(resultSet, config);
+      iter = IndirectArrowVectorIterator.create(resultSet, config);
       root = iter.next();
       iter.compositeConsumer.resetVectorSchemaRoot(root);
     }

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -130,6 +130,7 @@
             <exclude>**/*.checkstyle</exclude>
             <exclude>**/.classpath</exclude>
             <exclude>**/.settings/**</exclude>
+            <exclude>**/.factorypath</exclude>
             <exclude>.*/**</exclude>
             <exclude>**/*.patch</exclude>
             <exclude>**/*.pb.cc</exclude>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -402,14 +402,14 @@
             <forkCount>${forkCount}</forkCount>
             <reuseForks>true</reuseForks>
             <systemPropertyVariables>
+              <!-- Note: changing the below configuration might increase the max allocation size for a vector
+              which in turn can cause OOM. -->
+              <arrow.vector.max_allocation_bytes>1048576</arrow.vector.max_allocation_bytes>
               <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
               <io.netty.tryReflectionSetAccessible>true</io.netty.tryReflectionSetAccessible>
               <arrow.vector.max_allocation_bytes>1048576</arrow.vector.max_allocation_bytes>
               <user.timezone>UTC</user.timezone>
             </systemPropertyVariables>
-            <!-- Note: changing the below configuration might increase the max allocation size for a vector
-            which in turn can cause OOM. -->
-            <argLine>-Darrow.vector.max_allocation_bytes=1048576</argLine>
           </configuration>
         </plugin>
         <plugin>

--- a/java/vector/src/main/java/org/apache/arrow/sql/ArrowResultSet.java
+++ b/java/vector/src/main/java/org/apache/arrow/sql/ArrowResultSet.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.sql;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Wrapper;
+
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.dictionary.DictionaryProvider;
+import org.apache.arrow.vector.types.pojo.Schema;
+
+/**
+ * An interface to unwrap {@link ResultSet} into a sequence of Arrow vectors.
+ *
+ * The interface is intended for JDBC drivers using Arrow format internally, as a way
+ * to bypass deserialization and directly consume arrow vectors.
+ *
+ */
+public interface ArrowResultSet extends Wrapper, AutoCloseable {
+
+  /**
+   * Moves the cursor to the next vector.
+   *
+   * The cursor is initially positioned before the first vector.
+   *
+   * Any call to <code>next</code> method invalidates the current root vector
+   * before attempting to fetch the next one.
+   *
+   * When the method returns <code>false</code>, any attempt at accessing
+   * the root vector will throw <code>SQLException</code>.
+   * <code>false</code> if there are no more vectors
+   *
+   * @return <code>true</code> if the new current vector is valid.
+   * @throws SQLException if a database exception occurs
+   */
+  boolean next() throws SQLException;
+
+  /**
+   * Closes the result set and all resources associated with it (including
+   * the source {@code} ResultSet).
+   *
+   * @throws SQLException if a database exception occurs
+   */
+  @Override
+  void close() throws SQLException;
+
+  /**
+   * Retrieves if the result set has been closed, or not.
+   *
+   * @return <code>true</code> if the result is closed,
+   * <code>false</code> otherwise.
+   * @throws SQLException if a database exception occurs
+   */
+  boolean isClosed() throws SQLException;
+
+  /**
+   * Get the current vector data from the stream.
+   *
+   * <p>The data in the root may change at any time. Clients should NOT modify the root, but instead unload the data
+   * into their own root.
+   *
+   * @throws SQLException if there was an error reading the schema from the stream.
+   */
+  VectorSchemaRoot getRoot() throws SQLException;
+
+  /**
+   * Get the schema for this stream.
+   */
+  Schema getSchema() throws SQLException;
+
+  /**
+   * Get the provider for dictionaries in this stream.
+   *
+   * <p>Does NOT retain a reference to the underlying dictionaries. Dictionaries may be updated as the stream is read.
+   * This method is intended for stream processing, where the application code will not retain references to values
+   * after the stream is closed.
+   */
+  DictionaryProvider getDictionaryProvider() throws SQLException;
+}


### PR DESCRIPTION
Proof of concept

Add an new interface `ArrowResultSet` to be optionally implemented by JDBC drivers to allow `java.sql.ResultSet` to be unwrapped into a sequence of Arrow vectors and bypass JDBC serialization.